### PR TITLE
Update ejs dependencies from 1.0.0 to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://raw.github.com/tommy351/hexo/master/LICENSE"
   },
   "dependencies": {
-    "ejs": "^1.0.0",
+    "ejs": "^2.3.1",
     "lodash": "^2.4.1"
   }
 }


### PR DESCRIPTION
With 1.0.0 we are limited to this kind of include: `<%- include filePath %>`.
With newer version we can also do this kind of include: `<%- include('filePath', locals) %>`
