### PR TITLE
Upgrade ejs to v2 (w/ comments support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
   "dependencies": {
-    "ejs": "^1.0.0",
+    "ejs": "^2.3.4",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,15 @@ describe('EJS renderer', function() {
     result.should.eql('Hello world');
   });
 
+  it('comments', function() {
+    var body = [
+      'Comment <%# hidden %>'
+    ].join('\n');
+
+    var result = r({text: body});
+    result.should.eql('Comment ');
+  });
+
   it('include', function() {
     var body = [
       '<% include test %>'


### PR DESCRIPTION
This PR modifies the dependencies to use the latest ejs v2.3.4, which includes support for comments `<%# ... %>`. Also, a unit test was added for comments support (fails with ejs v1).

I did some manual smoke testing with a few different themes and did not encounter any issues, but there is still a risk of breaking changes for existing Hexo users:

> NOTE: Version 2 of EJS makes some breaking changes with this version (notably, removal of the filters feature).

**Feel free to close and ignore this PR if the risk is too great.** A `hexo-renderer-ejs2` could be created as an alternative, giving users the option to migrate when/if they choose.
