### PR TITLE
chore(eslint): use eslint instead of jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "excludeFiles": ["node_modules/**", "coverage/**", "tmp/**"],
-  "preset": "hexo"
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ node_js:
 
 script:
   - npm run eslint
-  - npm run jscs
   - npm run test-cov
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: node_js
 
 sudo: false
 
-cache:
-  apt: true
-  directories:
-    - node_modules
+cache: false
 
 node_js:
   - "6"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index",
   "scripts": {
     "eslint": "eslint .",
-    "jscs": "jscs .",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
@@ -25,12 +24,10 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^1.10.3",
-    "eslint-config-hexo": "^1.0.2",
+    "eslint": "^5.8.0",
+    "eslint-config-hexo": "^3.0.0",
     "hexo-fs": "^0.2.0",
     "istanbul": "^0.4.1",
-    "jscs": "^2.7.0",
-    "jscs-preset-hexo": "^1.0.1",
     "mocha": "^2.3.4"
   },
   "engines": {


### PR DESCRIPTION
Update eslint and delete jscs.
[jscs has already merged with eslint](https://www.npmjs.com/package/jscs). This PR update eslint and it version include merged jscs.