### PR TITLE
Prototype Pollution in async

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "ejs": "^3.1.6"
+    "ejs": "^3.1.7"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
```
hexo-renderer-ejs@2.0.0 requires async@0.9.x via a transitive dependency on jake@10.8.4
```

> The earliest fixed version is `2.6.4`.

> A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the mapValues() method.

update `ejs` to `3.1.7`

https://github.com/mde/ejs/commit/c028c343c127859f7189c3feee1e5239c199fec9
https://github.com/jakejs/jake/pull/411
